### PR TITLE
Fix autoprefixer invocation

### DIFF
--- a/techs/css-autoprefixer.js
+++ b/techs/css-autoprefixer.js
@@ -10,12 +10,12 @@ module.exports = require('enb/lib/build-flow').create()
     .target('destTarget', '?.css')
     .useSourceText('sourceTarget')
     .builder(function (css) {
-        var autoprefixerInstance = this._browserSupport ?
-            autoprefixer.apply(autoprefixer, {browsers: this._browserSupport}) :
-            autoprefixer;
+        var prefixer = autoprefixer({
+            browsers: this._browserSupport || autoprefixer.default
+        });
 
         try {
-            return autoprefixerInstance.process(css).css;
+            return prefixer.process(css).css;
         } catch (e) {
             throw new Error(e);
         }


### PR DESCRIPTION
Before this patch enb-autoprefixer always process files with default `browserSupport` because of incorrect `apply` with object argument instead of an array.
Because of this we always stepping in this code branch:
https://github.com/postcss/autoprefixer-core/blob/master/lib/autoprefixer.coffee#L24
instead of this:
https://github.com/postcss/autoprefixer-core/blob/master/lib/autoprefixer.coffee#L21

Instead of wrapping arguments in array invocation logic borrowed from grunt-autoprefixer which seems to be closer to [official usage recommendation](https://github.com/postcss/autoprefixer-core#usage).

Here's results after processing same css file with option browserSupport: **"last 8 Chrome versions"**
(before/after)
https://yadi.sk/i/x4Fz01G_dgviQ
https://yadi.sk/i/LhLlmbXOdgvi4
Notice that `-moz-box-sizing`, `-webkit-linear-gradient`, `-ms/moz-user-select` props removed and `-moz-font-kerning` is no longer being added as expected.